### PR TITLE
Add isCache on StoreService

### DIFF
--- a/store2store/src/androidTest/java/com/playmoweb/store2store/mock/MemoryDao.java
+++ b/store2store/src/androidTest/java/com/playmoweb/store2store/mock/MemoryDao.java
@@ -6,6 +6,7 @@ import com.playmoweb.store2store.utils.Filter;
 import com.playmoweb.store2store.utils.SortType;
 import com.playmoweb.store2store.utils.SortingMode;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,8 +46,17 @@ public class MemoryDao extends StoreDao<TestModel> {
 
     @Override
     public Flowable<Optional<TestModel>> getOne(Filter filter, SortingMode sortingMode) {
-        if(sortingMode != null && sortingMode.sort == SortType.DESCENDING){
-            return Flowable.just(Optional.wrap(models.get(models.size() - 1)));
+        if(sortingMode != null){
+            boolean reverse = false;
+            for(AbstractMap.SimpleEntry<String, SortType> e : sortingMode.entries){
+                if(e.getValue() == SortType.DESCENDING){
+                    reverse = true;
+                    break;
+                }
+            }
+            if(reverse) {
+                return Flowable.just(Optional.wrap(models.get(models.size() - 1)));
+            }
         }
         return Flowable.just(Optional.wrap(models.get(0)));
     }

--- a/store2store/src/androidTest/java/com/playmoweb/store2store/mock/TestStore.java
+++ b/store2store/src/androidTest/java/com/playmoweb/store2store/mock/TestStore.java
@@ -7,6 +7,7 @@ import com.playmoweb.store2store.utils.Filter;
 import com.playmoweb.store2store.utils.SortType;
 import com.playmoweb.store2store.utils.SortingMode;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,8 +45,17 @@ public class TestStore extends StoreService<TestModel> {
             list.add(new TestModel(20));
             list.add(new TestModel(30));
 
-            if(sortingMode != null && sortingMode.sort == SortType.DESCENDING){
-                Collections.reverse(list);
+            if(sortingMode != null){
+                boolean reverse = false;
+                for(AbstractMap.SimpleEntry<String, SortType> e : sortingMode.entries){
+                    if(e.getValue() == SortType.DESCENDING){
+                        reverse = true;
+                        break;
+                    }
+                }
+                if(reverse) {
+                    Collections.reverse(list);
+                }
             }
 
             return Flowable.just(Optional.wrap(list)).delay(1, TimeUnit.SECONDS);


### PR DESCRIPTION
- Add an attribute to allow StoreService to answer as a cache and not only as a syncedStore. This mean, the response will wait for the cache store before getting datas from the other store. A store must be declared as cache on initialization (constructor).